### PR TITLE
Add countries_names.json data mapping

### DIFF
--- a/src/data/countries_names.json
+++ b/src/data/countries_names.json
@@ -1,0 +1,1508 @@
+[
+  {
+    "key": "Andorra",
+    "latitude": 42.546245,
+    "longitude": 1.601554,
+    "name": "Andorra"
+  },
+  {
+    "key": "United Arab Emirates",
+    "latitude": 23.424076,
+    "longitude": 53.847818,
+    "name": "United Arab Emirates"
+  },
+  {
+    "key": "Afghanistan",
+    "latitude": 33.93911,
+    "longitude": 67.709953,
+    "name": "Afghanistan"
+  },
+  {
+    "key": "Antigua and Barbuda",
+    "latitude": 17.060816,
+    "longitude": -61.796428,
+    "name": "Antigua and Barbuda"
+  },
+  {
+    "key": "Anguilla",
+    "latitude": 18.220554,
+    "longitude": -63.068615,
+    "name": "Anguilla"
+  },
+  {
+    "key": "Albania",
+    "latitude": 41.153332,
+    "longitude": 20.168331,
+    "name": "Albania"
+  },
+  {
+    "key": "Armenia",
+    "latitude": 40.069099,
+    "longitude": 45.038189,
+    "name": "Armenia"
+  },
+  {
+    "key": "Netherlands Antilles",
+    "latitude": 12.226079,
+    "longitude": -69.060087,
+    "name": "Netherlands Antilles"
+  },
+  {
+    "key": "Angola",
+    "latitude": -11.202692,
+    "longitude": 17.873887,
+    "name": "Angola"
+  },
+  {
+    "key": "Antarctica",
+    "latitude": -75.250973,
+    "longitude": -0.071389,
+    "name": "Antarctica"
+  },
+  {
+    "key": "Argentina",
+    "latitude": -38.416097,
+    "longitude": -63.616672,
+    "name": "Argentina"
+  },
+  {
+    "key": "American Samoa",
+    "latitude": -14.270972,
+    "longitude": -170.132217,
+    "name": "American Samoa"
+  },
+  {
+    "key": "Austria",
+    "latitude": 47.516231,
+    "longitude": 14.550072,
+    "name": "Austria"
+  },
+  {
+    "key": "Australia",
+    "latitude": -25.274398,
+    "longitude": 133.775136,
+    "name": "Australia"
+  },
+  {
+    "key": "Aruba",
+    "latitude": 12.52111,
+    "longitude": -69.968338,
+    "name": "Aruba"
+  },
+  {
+    "key": "Åland",
+    "latitude": 60.3385485,
+    "longitude": 20.2712585,
+    "name": "Åland"
+  },
+  {
+    "key": "Azerbaijan",
+    "latitude": 40.143105,
+    "longitude": 47.576927,
+    "name": "Azerbaijan"
+  },
+  {
+    "key": "Bosnia and Herzegovina",
+    "latitude": 43.915886,
+    "longitude": 17.679076,
+    "name": "Bosnia and Herzegovina"
+  },
+  {
+    "key": "Barbados",
+    "latitude": 13.193887,
+    "longitude": -59.543198,
+    "name": "Barbados"
+  },
+  {
+    "key": "Bangladesh",
+    "latitude": 23.684994,
+    "longitude": 90.356331,
+    "name": "Bangladesh"
+  },
+  {
+    "key": "Belgium",
+    "latitude": 50.503887,
+    "longitude": 4.469936,
+    "name": "Belgium"
+  },
+  {
+    "key": "Burkina Faso",
+    "latitude": 12.238333,
+    "longitude": -1.561593,
+    "name": "Burkina Faso"
+  },
+  {
+    "key": "Bulgaria",
+    "latitude": 42.733883,
+    "longitude": 25.48583,
+    "name": "Bulgaria"
+  },
+  {
+    "key": "Bahrain",
+    "latitude": 25.930414,
+    "longitude": 50.637772,
+    "name": "Bahrain"
+  },
+  {
+    "key": "Burundi",
+    "latitude": -3.373056,
+    "longitude": 29.918886,
+    "name": "Burundi"
+  },
+  {
+    "key": "Benin",
+    "latitude": 9.30769,
+    "longitude": 2.315834,
+    "name": "Benin"
+  },
+  {
+    "key": "Saint-Barthélemy",
+    "latitude": 17.9,
+    "longitude": -62.833333,
+    "name": "Saint-Barthélemy"
+  },
+  {
+    "key": "Bermuda",
+    "latitude": 32.321384,
+    "longitude": -64.75737,
+    "name": "Bermuda"
+  },
+  {
+    "key": "Brunei",
+    "latitude": 4.535277,
+    "longitude": 114.727669,
+    "name": "Brunei"
+  },
+  {
+    "key": "Bolivia",
+    "latitude": -16.290154,
+    "longitude": -63.588653,
+    "name": "Bolivia"
+  },
+  {
+    "key": "Bonaire, Sint Eustatius, and Saba",
+    "latitude": 12.1783611,
+    "longitude": -68.2385339,
+    "name": "Bonaire, Sint Eustatius, and Saba"
+  },
+  {
+    "key": "Brazil",
+    "latitude": -14.235004,
+    "longitude": -51.92528,
+    "name": "Brazil"
+  },
+  {
+    "key": "Bahamas",
+    "latitude": 25.03428,
+    "longitude": -77.39628,
+    "name": "Bahamas"
+  },
+  {
+    "key": "Bhutan",
+    "latitude": 27.514162,
+    "longitude": 90.433601,
+    "name": "Bhutan"
+  },
+  {
+    "key": "Bouvet Island",
+    "latitude": -54.423199,
+    "longitude": 3.413194,
+    "name": "Bouvet Island"
+  },
+  {
+    "key": "Botswana",
+    "latitude": -22.328474,
+    "longitude": 24.684866,
+    "name": "Botswana"
+  },
+  {
+    "key": "Belarus",
+    "latitude": 53.709807,
+    "longitude": 27.953389,
+    "name": "Belarus"
+  },
+  {
+    "key": "Belize",
+    "latitude": 17.189877,
+    "longitude": -88.49765,
+    "name": "Belize"
+  },
+  {
+    "key": "Canada",
+    "latitude": 56.130366,
+    "longitude": -106.346771,
+    "name": "Canada"
+  },
+  {
+    "key": "Cocos [Keeling] Islands",
+    "latitude": -12.164165,
+    "longitude": 96.870956,
+    "name": "Cocos [Keeling] Islands"
+  },
+  {
+    "key": "Congo [DRC]",
+    "latitude": -4.038333,
+    "longitude": 21.758664,
+    "name": "Congo [DRC]"
+  },
+  {
+    "key": "Central African Republic",
+    "latitude": 6.611111,
+    "longitude": 20.939444,
+    "name": "Central African Republic"
+  },
+  {
+    "key": "Congo [Republic]",
+    "latitude": -0.228021,
+    "longitude": 15.827659,
+    "name": "Congo [Republic]"
+  },
+  {
+    "key": "Switzerland",
+    "latitude": 46.818188,
+    "longitude": 8.227512,
+    "name": "Switzerland"
+  },
+  {
+    "key": "Côte d'Ivoire",
+    "latitude": 7.539989,
+    "longitude": -5.54708,
+    "name": "Côte d'Ivoire"
+  },
+  {
+    "key": "Cook Islands",
+    "latitude": -21.236736,
+    "longitude": -159.777671,
+    "name": "Cook Islands"
+  },
+  {
+    "key": "Chile",
+    "latitude": -35.675147,
+    "longitude": -71.542969,
+    "name": "Chile"
+  },
+  {
+    "key": "Cameroon",
+    "latitude": 7.369722,
+    "longitude": 12.354722,
+    "name": "Cameroon"
+  },
+  {
+    "key": "China",
+    "latitude": 35.86166,
+    "longitude": 104.195397,
+    "name": "China"
+  },
+  {
+    "key": "Colombia",
+    "latitude": 4.570868,
+    "longitude": -74.297333,
+    "name": "Colombia"
+  },
+  {
+    "key": "Costa Rica",
+    "latitude": 9.748917,
+    "longitude": -83.753428,
+    "name": "Costa Rica"
+  },
+  {
+    "key": "Cuba",
+    "latitude": 21.521757,
+    "longitude": -77.781167,
+    "name": "Cuba"
+  },
+  {
+    "key": "Cape Verde",
+    "latitude": 16.002082,
+    "longitude": -24.013197,
+    "name": "Cape Verde"
+  },
+  {
+    "key": "Curaçao",
+    "latitude": 12.16957,
+    "longitude": -68.99002,
+    "name": "Curaçao"
+  },
+  {
+    "key": "Christmas Island",
+    "latitude": -10.447525,
+    "longitude": 105.690449,
+    "name": "Christmas Island"
+  },
+  {
+    "key": "Cyprus",
+    "latitude": 35.126413,
+    "longitude": 33.429859,
+    "name": "Cyprus"
+  },
+  {
+    "key": "Czech Republic",
+    "latitude": 49.817492,
+    "longitude": 15.472962,
+    "name": "Czech Republic"
+  },
+  {
+    "key": "Germany",
+    "latitude": 51.165691,
+    "longitude": 10.451526,
+    "name": "Germany"
+  },
+  {
+    "key": "Djibouti",
+    "latitude": 11.825138,
+    "longitude": 42.590275,
+    "name": "Djibouti"
+  },
+  {
+    "key": "Denmark",
+    "latitude": 56.26392,
+    "longitude": 9.501785,
+    "name": "Denmark"
+  },
+  {
+    "key": "Dominica",
+    "latitude": 15.414999,
+    "longitude": -61.370976,
+    "name": "Dominica"
+  },
+  {
+    "key": "Dominican Republic",
+    "latitude": 18.735693,
+    "longitude": -70.162651,
+    "name": "Dominican Republic"
+  },
+  {
+    "key": "Algeria",
+    "latitude": 28.033886,
+    "longitude": 1.659626,
+    "name": "Algeria"
+  },
+  {
+    "key": "Ecuador",
+    "latitude": -1.831239,
+    "longitude": -78.183406,
+    "name": "Ecuador"
+  },
+  {
+    "key": "Estonia",
+    "latitude": 58.595272,
+    "longitude": 25.013607,
+    "name": "Estonia"
+  },
+  {
+    "key": "Egypt",
+    "latitude": 26.820553,
+    "longitude": 30.802498,
+    "name": "Egypt"
+  },
+  {
+    "key": "Western Sahara",
+    "latitude": 24.215527,
+    "longitude": -12.885834,
+    "name": "Western Sahara"
+  },
+  {
+    "key": "Eritrea",
+    "latitude": 15.179384,
+    "longitude": 39.782334,
+    "name": "Eritrea"
+  },
+  {
+    "key": "Spain",
+    "latitude": 40.463667,
+    "longitude": -3.74922,
+    "name": "Spain"
+  },
+  {
+    "key": "Ethiopia",
+    "latitude": 9.145,
+    "longitude": 40.489673,
+    "name": "Ethiopia"
+  },
+  {
+    "key": "Finland",
+    "latitude": 61.92411,
+    "longitude": 25.748151,
+    "name": "Finland"
+  },
+  {
+    "key": "Fiji",
+    "latitude": -16.578193,
+    "longitude": 179.414413,
+    "name": "Fiji"
+  },
+  {
+    "key": "Falkland Islands [Islas Malvinas]",
+    "latitude": -51.796253,
+    "longitude": -59.523613,
+    "name": "Falkland Islands [Islas Malvinas]"
+  },
+  {
+    "key": "Micronesia",
+    "latitude": 7.425554,
+    "longitude": 150.550812,
+    "name": "Micronesia"
+  },
+  {
+    "key": "Faroe Islands",
+    "latitude": 61.892635,
+    "longitude": -6.911806,
+    "name": "Faroe Islands"
+  },
+  {
+    "key": "France",
+    "latitude": 46.227638,
+    "longitude": 2.213749,
+    "name": "France"
+  },
+  {
+    "key": "Gabon",
+    "latitude": -0.803689,
+    "longitude": 11.609444,
+    "name": "Gabon"
+  },
+  {
+    "key": "United Kingdom",
+    "latitude": 55.378051,
+    "longitude": -3.435973,
+    "name": "United Kingdom"
+  },
+  {
+    "key": "Grenada",
+    "latitude": 12.262776,
+    "longitude": -61.604171,
+    "name": "Grenada"
+  },
+  {
+    "key": "Georgia",
+    "latitude": 42.315407,
+    "longitude": 43.356892,
+    "name": "Georgia"
+  },
+  {
+    "key": "French Guiana",
+    "latitude": 3.933889,
+    "longitude": -53.125782,
+    "name": "French Guiana"
+  },
+  {
+    "key": "Guernsey",
+    "latitude": 49.465691,
+    "longitude": -2.585278,
+    "name": "Guernsey"
+  },
+  {
+    "key": "Ghana",
+    "latitude": 7.946527,
+    "longitude": -1.023194,
+    "name": "Ghana"
+  },
+  {
+    "key": "Gibraltar",
+    "latitude": 36.137741,
+    "longitude": -5.345374,
+    "name": "Gibraltar"
+  },
+  {
+    "key": "Greenland",
+    "latitude": 71.706936,
+    "longitude": -42.604303,
+    "name": "Greenland"
+  },
+  {
+    "key": "Gambia",
+    "latitude": 13.443182,
+    "longitude": -15.310139,
+    "name": "Gambia"
+  },
+  {
+    "key": "Guinea",
+    "latitude": 9.945587,
+    "longitude": -9.696645,
+    "name": "Guinea"
+  },
+  {
+    "key": "Guadeloupe",
+    "latitude": 16.995971,
+    "longitude": -62.067641,
+    "name": "Guadeloupe"
+  },
+  {
+    "key": "Equatorial Guinea",
+    "latitude": 1.650801,
+    "longitude": 10.267895,
+    "name": "Equatorial Guinea"
+  },
+  {
+    "key": "Greece",
+    "latitude": 39.074208,
+    "longitude": 21.824312,
+    "name": "Greece"
+  },
+  {
+    "key": "South Georgia and the South Sandwich Islands",
+    "latitude": -54.429579,
+    "longitude": -36.587909,
+    "name": "South Georgia and the South Sandwich Islands"
+  },
+  {
+    "key": "Guatemala",
+    "latitude": 15.783471,
+    "longitude": -90.230759,
+    "name": "Guatemala"
+  },
+  {
+    "key": "Guam",
+    "latitude": 13.444304,
+    "longitude": 144.793731,
+    "name": "Guam"
+  },
+  {
+    "key": "Guinea-Bissau",
+    "latitude": 11.803749,
+    "longitude": -15.180413,
+    "name": "Guinea-Bissau"
+  },
+  {
+    "key": "Guyana",
+    "latitude": 4.860416,
+    "longitude": -58.93018,
+    "name": "Guyana"
+  },
+  {
+    "key": "Gaza Strip",
+    "latitude": 31.354676,
+    "longitude": 34.308825,
+    "name": "Gaza Strip"
+  },
+  {
+    "key": "Hong Kong",
+    "latitude": 22.396428,
+    "longitude": 114.109497,
+    "name": "Hong Kong"
+  },
+  {
+    "key": "Heard Island and McDonald Islands",
+    "latitude": -53.08181,
+    "longitude": 73.504158,
+    "name": "Heard Island and McDonald Islands"
+  },
+  {
+    "key": "Honduras",
+    "latitude": 15.199999,
+    "longitude": -86.241905,
+    "name": "Honduras"
+  },
+  {
+    "key": "Croatia",
+    "latitude": 45.1,
+    "longitude": 15.2,
+    "name": "Croatia"
+  },
+  {
+    "key": "Haiti",
+    "latitude": 18.971187,
+    "longitude": -72.285215,
+    "name": "Haiti"
+  },
+  {
+    "key": "Hungary",
+    "latitude": 47.162494,
+    "longitude": 19.503304,
+    "name": "Hungary"
+  },
+  {
+    "key": "Indonesia",
+    "latitude": -0.789275,
+    "longitude": 113.921327,
+    "name": "Indonesia"
+  },
+  {
+    "key": "Ireland",
+    "latitude": 53.41291,
+    "longitude": -8.24389,
+    "name": "Ireland"
+  },
+  {
+    "key": "Israel",
+    "latitude": 31.046051,
+    "longitude": 34.851612,
+    "name": "Israel"
+  },
+  {
+    "key": "Isle of Man",
+    "latitude": 54.236107,
+    "longitude": -4.548056,
+    "name": "Isle of Man"
+  },
+  {
+    "key": "India",
+    "latitude": 20.593684,
+    "longitude": 78.96288,
+    "name": "India"
+  },
+  {
+    "key": "British Indian Ocean Territory",
+    "latitude": -6.343194,
+    "longitude": 71.876519,
+    "name": "British Indian Ocean Territory"
+  },
+  {
+    "key": "Iraq",
+    "latitude": 33.223191,
+    "longitude": 43.679291,
+    "name": "Iraq"
+  },
+  {
+    "key": "Iran",
+    "latitude": 32.427908,
+    "longitude": 53.688046,
+    "name": "Iran"
+  },
+  {
+    "key": "Iceland",
+    "latitude": 64.963051,
+    "longitude": -19.020835,
+    "name": "Iceland"
+  },
+  {
+    "key": "Italy",
+    "latitude": 41.87194,
+    "longitude": 12.56738,
+    "name": "Italy"
+  },
+  {
+    "key": "Jersey",
+    "latitude": 49.214439,
+    "longitude": -2.13125,
+    "name": "Jersey"
+  },
+  {
+    "key": "Jamaica",
+    "latitude": 18.109581,
+    "longitude": -77.297508,
+    "name": "Jamaica"
+  },
+  {
+    "key": "Jordan",
+    "latitude": 30.585164,
+    "longitude": 36.238414,
+    "name": "Jordan"
+  },
+  {
+    "key": "Japan",
+    "latitude": 36.204824,
+    "longitude": 138.252924,
+    "name": "Japan"
+  },
+  {
+    "key": "Kenya",
+    "latitude": -0.023559,
+    "longitude": 37.906193,
+    "name": "Kenya"
+  },
+  {
+    "key": "Kyrgyzstan",
+    "latitude": 41.20438,
+    "longitude": 74.766098,
+    "name": "Kyrgyzstan"
+  },
+  {
+    "key": "Cambodia",
+    "latitude": 12.565679,
+    "longitude": 104.990963,
+    "name": "Cambodia"
+  },
+  {
+    "key": "Kiribati",
+    "latitude": -3.370417,
+    "longitude": -168.734039,
+    "name": "Kiribati"
+  },
+  {
+    "key": "Comoros",
+    "latitude": -11.875001,
+    "longitude": 43.872219,
+    "name": "Comoros"
+  },
+  {
+    "key": "Saint Kitts and Nevis",
+    "latitude": 17.357822,
+    "longitude": -62.782998,
+    "name": "Saint Kitts and Nevis"
+  },
+  {
+    "key": "North Korea",
+    "latitude": 40.339852,
+    "longitude": 127.510093,
+    "name": "North Korea"
+  },
+  {
+    "key": "South Korea",
+    "latitude": 35.907757,
+    "longitude": 127.766922,
+    "name": "South Korea"
+  },
+  {
+    "key": "Kuwait",
+    "latitude": 29.31166,
+    "longitude": 47.481766,
+    "name": "Kuwait"
+  },
+  {
+    "key": "Cayman Islands",
+    "latitude": 19.513469,
+    "longitude": -80.566956,
+    "name": "Cayman Islands"
+  },
+  {
+    "key": "Kazakhstan",
+    "latitude": 48.019573,
+    "longitude": 66.923684,
+    "name": "Kazakhstan"
+  },
+  {
+    "key": "Laos",
+    "latitude": 19.85627,
+    "longitude": 102.495496,
+    "name": "Laos"
+  },
+  {
+    "key": "Lebanon",
+    "latitude": 33.854721,
+    "longitude": 35.862285,
+    "name": "Lebanon"
+  },
+  {
+    "key": "Saint Lucia",
+    "latitude": 13.909444,
+    "longitude": -60.978893,
+    "name": "Saint Lucia"
+  },
+  {
+    "key": "Liechtenstein",
+    "latitude": 47.166,
+    "longitude": 9.555373,
+    "name": "Liechtenstein"
+  },
+  {
+    "key": "Sri Lanka",
+    "latitude": 7.873054,
+    "longitude": 80.771797,
+    "name": "Sri Lanka"
+  },
+  {
+    "key": "Liberia",
+    "latitude": 6.428055,
+    "longitude": -9.429499,
+    "name": "Liberia"
+  },
+  {
+    "key": "Lesotho",
+    "latitude": -29.609988,
+    "longitude": 28.233608,
+    "name": "Lesotho"
+  },
+  {
+    "key": "Lithuania",
+    "latitude": 55.169438,
+    "longitude": 23.881275,
+    "name": "Lithuania"
+  },
+  {
+    "key": "Luxembourg",
+    "latitude": 49.815273,
+    "longitude": 6.129583,
+    "name": "Luxembourg"
+  },
+  {
+    "key": "Latvia",
+    "latitude": 56.879635,
+    "longitude": 24.603189,
+    "name": "Latvia"
+  },
+  {
+    "key": "Libya",
+    "latitude": 26.3351,
+    "longitude": 17.228331,
+    "name": "Libya"
+  },
+  {
+    "key": "Morocco",
+    "latitude": 31.791702,
+    "longitude": -7.09262,
+    "name": "Morocco"
+  },
+  {
+    "key": "Monaco",
+    "latitude": 43.750298,
+    "longitude": 7.412841,
+    "name": "Monaco"
+  },
+  {
+    "key": "Moldova",
+    "latitude": 47.411631,
+    "longitude": 28.369885,
+    "name": "Moldova"
+  },
+  {
+    "key": "Montenegro",
+    "latitude": 42.708678,
+    "longitude": 19.37439,
+    "name": "Montenegro"
+  },
+  {
+    "key": "Saint Martin",
+    "latitude": 18.08255,
+    "longitude": -63.052251,
+    "name": "Saint Martin"
+  },
+  {
+    "key": "Madagascar",
+    "latitude": -18.766947,
+    "longitude": 46.869107,
+    "name": "Madagascar"
+  },
+  {
+    "key": "Marshall Islands",
+    "latitude": 7.131474,
+    "longitude": 171.184478,
+    "name": "Marshall Islands"
+  },
+  {
+    "key": "Macedonia [FYROM]",
+    "latitude": 41.608635,
+    "longitude": 21.745275,
+    "name": "Macedonia [FYROM]"
+  },
+  {
+    "key": "Mali",
+    "latitude": 17.570692,
+    "longitude": -3.996166,
+    "name": "Mali"
+  },
+  {
+    "key": "Myanmar [Burma]",
+    "latitude": 21.913965,
+    "longitude": 95.956223,
+    "name": "Myanmar [Burma]"
+  },
+  {
+    "key": "Mongolia",
+    "latitude": 46.862496,
+    "longitude": 103.846656,
+    "name": "Mongolia"
+  },
+  {
+    "key": "Macau",
+    "latitude": 22.198745,
+    "longitude": 113.543873,
+    "name": "Macau"
+  },
+  {
+    "key": "Northern Mariana Islands",
+    "latitude": 17.33083,
+    "longitude": 145.38469,
+    "name": "Northern Mariana Islands"
+  },
+  {
+    "key": "Martinique",
+    "latitude": 14.641528,
+    "longitude": -61.024174,
+    "name": "Martinique"
+  },
+  {
+    "key": "Mauritania",
+    "latitude": 21.00789,
+    "longitude": -10.940835,
+    "name": "Mauritania"
+  },
+  {
+    "key": "Montserrat",
+    "latitude": 16.742498,
+    "longitude": -62.187366,
+    "name": "Montserrat"
+  },
+  {
+    "key": "Malta",
+    "latitude": 35.937496,
+    "longitude": 14.375416,
+    "name": "Malta"
+  },
+  {
+    "key": "Mauritius",
+    "latitude": -20.348404,
+    "longitude": 57.552152,
+    "name": "Mauritius"
+  },
+  {
+    "key": "Maldives",
+    "latitude": 3.202778,
+    "longitude": 73.22068,
+    "name": "Maldives"
+  },
+  {
+    "key": "Malawi",
+    "latitude": -13.254308,
+    "longitude": 34.301525,
+    "name": "Malawi"
+  },
+  {
+    "key": "Mexico",
+    "latitude": 23.634501,
+    "longitude": -102.552784,
+    "name": "Mexico"
+  },
+  {
+    "key": "Malaysia",
+    "latitude": 4.210484,
+    "longitude": 101.975766,
+    "name": "Malaysia"
+  },
+  {
+    "key": "Mozambique",
+    "latitude": -18.665695,
+    "longitude": 35.529562,
+    "name": "Mozambique"
+  },
+  {
+    "key": "Namibia",
+    "latitude": -22.95764,
+    "longitude": 18.49041,
+    "name": "Namibia"
+  },
+  {
+    "key": "New Caledonia",
+    "latitude": -20.904305,
+    "longitude": 165.618042,
+    "name": "New Caledonia"
+  },
+  {
+    "key": "Niger",
+    "latitude": 17.607789,
+    "longitude": 8.081666,
+    "name": "Niger"
+  },
+  {
+    "key": "Norfolk Island",
+    "latitude": -29.040835,
+    "longitude": 167.954712,
+    "name": "Norfolk Island"
+  },
+  {
+    "key": "Nigeria",
+    "latitude": 9.081999,
+    "longitude": 8.675277,
+    "name": "Nigeria"
+  },
+  {
+    "key": "Nicaragua",
+    "latitude": 12.865416,
+    "longitude": -85.207229,
+    "name": "Nicaragua"
+  },
+  {
+    "key": "Netherlands",
+    "latitude": 52.132633,
+    "longitude": 5.291266,
+    "name": "Netherlands"
+  },
+  {
+    "key": "Norway",
+    "latitude": 60.472024,
+    "longitude": 8.468946,
+    "name": "Norway"
+  },
+  {
+    "key": "Nepal",
+    "latitude": 28.394857,
+    "longitude": 84.124008,
+    "name": "Nepal"
+  },
+  {
+    "key": "Nauru",
+    "latitude": -0.522778,
+    "longitude": 166.931503,
+    "name": "Nauru"
+  },
+  {
+    "key": "Niue",
+    "latitude": -19.054445,
+    "longitude": -169.867233,
+    "name": "Niue"
+  },
+  {
+    "key": "New Zealand",
+    "latitude": -40.900557,
+    "longitude": 174.885971,
+    "name": "New Zealand"
+  },
+  {
+    "key": "Oman",
+    "latitude": 21.512583,
+    "longitude": 55.923255,
+    "name": "Oman"
+  },
+  {
+    "key": "Panama",
+    "latitude": 8.537981,
+    "longitude": -80.782127,
+    "name": "Panama"
+  },
+  {
+    "key": "Peru",
+    "latitude": -9.189967,
+    "longitude": -75.015152,
+    "name": "Peru"
+  },
+  {
+    "key": "French Polynesia",
+    "latitude": -17.679742,
+    "longitude": -149.406843,
+    "name": "French Polynesia"
+  },
+  {
+    "key": "Papua New Guinea",
+    "latitude": -6.314993,
+    "longitude": 143.95555,
+    "name": "Papua New Guinea"
+  },
+  {
+    "key": "Philippines",
+    "latitude": 12.879721,
+    "longitude": 121.774017,
+    "name": "Philippines"
+  },
+  {
+    "key": "Pakistan",
+    "latitude": 30.375321,
+    "longitude": 69.345116,
+    "name": "Pakistan"
+  },
+  {
+    "key": "Poland",
+    "latitude": 51.919438,
+    "longitude": 19.145136,
+    "name": "Poland"
+  },
+  {
+    "key": "Saint Pierre and Miquelon",
+    "latitude": 46.941936,
+    "longitude": -56.27111,
+    "name": "Saint Pierre and Miquelon"
+  },
+  {
+    "key": "Pitcairn Islands",
+    "latitude": -24.703615,
+    "longitude": -127.439308,
+    "name": "Pitcairn Islands"
+  },
+  {
+    "key": "Puerto Rico",
+    "latitude": 18.220833,
+    "longitude": -66.590149,
+    "name": "Puerto Rico"
+  },
+  {
+    "key": "Palestinian Territories",
+    "latitude": 31.952162,
+    "longitude": 35.233154,
+    "name": "Palestinian Territories"
+  },
+  {
+    "key": "Portugal",
+    "latitude": 39.399872,
+    "longitude": -8.224454,
+    "name": "Portugal"
+  },
+  {
+    "key": "Palau",
+    "latitude": 7.51498,
+    "longitude": 134.58252,
+    "name": "Palau"
+  },
+  {
+    "key": "Paraguay",
+    "latitude": -23.442503,
+    "longitude": -58.443832,
+    "name": "Paraguay"
+  },
+  {
+    "key": "Qatar",
+    "latitude": 25.354826,
+    "longitude": 51.183884,
+    "name": "Qatar"
+  },
+  {
+    "key": "Réunion",
+    "latitude": -21.115141,
+    "longitude": 55.536384,
+    "name": "Réunion"
+  },
+  {
+    "key": "Romania",
+    "latitude": 45.943161,
+    "longitude": 24.96676,
+    "name": "Romania"
+  },
+  {
+    "key": "Serbia",
+    "latitude": 44.016521,
+    "longitude": 21.005859,
+    "name": "Serbia"
+  },
+  {
+    "key": "Russia",
+    "latitude": 61.52401,
+    "longitude": 105.318756,
+    "name": "Russia"
+  },
+  {
+    "key": "Rwanda",
+    "latitude": -1.940278,
+    "longitude": 29.873888,
+    "name": "Rwanda"
+  },
+  {
+    "key": "Saudi Arabia",
+    "latitude": 23.885942,
+    "longitude": 45.079162,
+    "name": "Saudi Arabia"
+  },
+  {
+    "key": "Solomon Islands",
+    "latitude": -9.64571,
+    "longitude": 160.156194,
+    "name": "Solomon Islands"
+  },
+  {
+    "key": "Seychelles",
+    "latitude": -4.679574,
+    "longitude": 55.491977,
+    "name": "Seychelles"
+  },
+  {
+    "key": "Sudan",
+    "latitude": 12.862807,
+    "longitude": 30.217636,
+    "name": "Sudan"
+  },
+  {
+    "key": "Sweden",
+    "latitude": 60.128161,
+    "longitude": 18.643501,
+    "name": "Sweden"
+  },
+  {
+    "key": "Singapore",
+    "latitude": 1.352083,
+    "longitude": 103.819836,
+    "name": "Singapore"
+  },
+  {
+    "key": "Saint Helena",
+    "latitude": -24.143474,
+    "longitude": -10.030696,
+    "name": "Saint Helena"
+  },
+  {
+    "key": "Slovenia",
+    "latitude": 46.151241,
+    "longitude": 14.995463,
+    "name": "Slovenia"
+  },
+  {
+    "key": "Svalbard and Jan Mayen",
+    "latitude": 77.553604,
+    "longitude": 23.670272,
+    "name": "Svalbard and Jan Mayen"
+  },
+  {
+    "key": "Slovakia",
+    "latitude": 48.669026,
+    "longitude": 19.699024,
+    "name": "Slovakia"
+  },
+  {
+    "key": "Sierra Leone",
+    "latitude": 8.460555,
+    "longitude": -11.779889,
+    "name": "Sierra Leone"
+  },
+  {
+    "key": "San Marino",
+    "latitude": 43.94236,
+    "longitude": 12.457777,
+    "name": "San Marino"
+  },
+  {
+    "key": "Senegal",
+    "latitude": 14.497401,
+    "longitude": -14.452362,
+    "name": "Senegal"
+  },
+  {
+    "key": "Somalia",
+    "latitude": 5.152149,
+    "longitude": 46.199616,
+    "name": "Somalia"
+  },
+  {
+    "key": "Suriname",
+    "latitude": 3.919305,
+    "longitude": -56.027783,
+    "name": "Suriname"
+  },
+  {
+    "key": "São Tomé and Príncipe",
+    "latitude": 0.18636,
+    "longitude": 6.613081,
+    "name": "São Tomé and Príncipe"
+  },
+  {
+    "key": "El Salvador",
+    "latitude": 13.794185,
+    "longitude": -88.89653,
+    "name": "El Salvador"
+  },
+  {
+    "key": "Sint Maarten",
+    "latitude": 18.030827,
+    "longitude": -63.073633,
+    "name": "Sint Maarten"
+  },
+  {
+    "key": "Syria",
+    "latitude": 34.802075,
+    "longitude": 38.996815,
+    "name": "Syria"
+  },
+  {
+    "key": "Swaziland",
+    "latitude": -26.522503,
+    "longitude": 31.465866,
+    "name": "Swaziland"
+  },
+  {
+    "key": "Turks and Caicos Islands",
+    "latitude": 21.694025,
+    "longitude": -71.797928,
+    "name": "Turks and Caicos Islands"
+  },
+  {
+    "key": "Chad",
+    "latitude": 15.454166,
+    "longitude": 18.732207,
+    "name": "Chad"
+  },
+  {
+    "key": "French Southern Territories",
+    "latitude": -49.280366,
+    "longitude": 69.348557,
+    "name": "French Southern Territories"
+  },
+  {
+    "key": "Togo",
+    "latitude": 8.619543,
+    "longitude": 0.824782,
+    "name": "Togo"
+  },
+  {
+    "key": "Thailand",
+    "latitude": 15.870032,
+    "longitude": 100.992541,
+    "name": "Thailand"
+  },
+  {
+    "key": "Tajikistan",
+    "latitude": 38.861034,
+    "longitude": 71.276093,
+    "name": "Tajikistan"
+  },
+  {
+    "key": "Tokelau",
+    "latitude": -8.967363,
+    "longitude": -171.855881,
+    "name": "Tokelau"
+  },
+  {
+    "key": "Timor-Leste",
+    "latitude": -8.874217,
+    "longitude": 125.727539,
+    "name": "Timor-Leste"
+  },
+  {
+    "key": "Turkmenistan",
+    "latitude": 38.969719,
+    "longitude": 59.556278,
+    "name": "Turkmenistan"
+  },
+  {
+    "key": "Tunisia",
+    "latitude": 33.886917,
+    "longitude": 9.537499,
+    "name": "Tunisia"
+  },
+  {
+    "key": "Tonga",
+    "latitude": -21.178986,
+    "longitude": -175.198242,
+    "name": "Tonga"
+  },
+  {
+    "key": "Turkey",
+    "latitude": 38.963745,
+    "longitude": 35.243322,
+    "name": "Turkey"
+  },
+  {
+    "key": "Trinidad and Tobago",
+    "latitude": 10.691803,
+    "longitude": -61.222503,
+    "name": "Trinidad and Tobago"
+  },
+  {
+    "key": "Tuvalu",
+    "latitude": -7.109535,
+    "longitude": 177.64933,
+    "name": "Tuvalu"
+  },
+  {
+    "key": "Taiwan",
+    "latitude": 23.69781,
+    "longitude": 120.960515,
+    "name": "Taiwan"
+  },
+  {
+    "key": "Tanzania",
+    "latitude": -6.369028,
+    "longitude": 34.888822,
+    "name": "Tanzania"
+  },
+  {
+    "key": "Ukraine",
+    "latitude": 48.379433,
+    "longitude": 31.16558,
+    "name": "Ukraine"
+  },
+  {
+    "key": "Uganda",
+    "latitude": 1.373333,
+    "longitude": 32.290275,
+    "name": "Uganda"
+  },
+  {
+    "key": "U.S. Minor Outlying Islands",
+    "latitude": 0,
+    "longitude": 0,
+    "name": "U.S. Minor Outlying Islands"
+  },
+  {
+    "key": "United States",
+    "latitude": 37.09024,
+    "longitude": -95.712891,
+    "name": "United States"
+  },
+  {
+    "key": "Uruguay",
+    "latitude": -32.522779,
+    "longitude": -55.765835,
+    "name": "Uruguay"
+  },
+  {
+    "key": "Uzbekistan",
+    "latitude": 41.377491,
+    "longitude": 64.585262,
+    "name": "Uzbekistan"
+  },
+  {
+    "key": "Vatican City",
+    "latitude": 41.902916,
+    "longitude": 12.453389,
+    "name": "Vatican City"
+  },
+  {
+    "key": "Saint Vincent and the Grenadines",
+    "latitude": 12.984305,
+    "longitude": -61.287228,
+    "name": "Saint Vincent and the Grenadines"
+  },
+  {
+    "key": "Venezuela",
+    "latitude": 6.42375,
+    "longitude": -66.58973,
+    "name": "Venezuela"
+  },
+  {
+    "key": "British Virgin Islands",
+    "latitude": 18.420695,
+    "longitude": -64.639968,
+    "name": "British Virgin Islands"
+  },
+  {
+    "key": "U.S. Virgin Islands",
+    "latitude": 18.335765,
+    "longitude": -64.896335,
+    "name": "U.S. Virgin Islands"
+  },
+  {
+    "key": "Vietnam",
+    "latitude": 14.058324,
+    "longitude": 108.277199,
+    "name": "Vietnam"
+  },
+  {
+    "key": "Vanuatu",
+    "latitude": -15.376706,
+    "longitude": 166.959158,
+    "name": "Vanuatu"
+  },
+  {
+    "key": "Wallis and Futuna",
+    "latitude": -13.768752,
+    "longitude": -177.156097,
+    "name": "Wallis and Futuna"
+  },
+  {
+    "key": "Samoa",
+    "latitude": -13.759029,
+    "longitude": -172.104629,
+    "name": "Samoa"
+  },
+  {
+    "key": "Kosovo",
+    "latitude": 42.602636,
+    "longitude": 20.902977,
+    "name": "Kosovo"
+  },
+  {
+    "key": "Yemen",
+    "latitude": 15.552727,
+    "longitude": 48.516388,
+    "name": "Yemen"
+  },
+  {
+    "key": "Mayotte",
+    "latitude": -12.8275,
+    "longitude": 45.166244,
+    "name": "Mayotte"
+  },
+  {
+    "key": "South Africa",
+    "latitude": -30.559482,
+    "longitude": 22.937506,
+    "name": "South Africa"
+  },
+  {
+    "key": "Zambia",
+    "latitude": -13.133897,
+    "longitude": 27.849332,
+    "name": "Zambia"
+  },
+  {
+    "key": "Zimbabwe",
+    "latitude": -19.015438,
+    "longitude": 29.154857,
+    "name": "Zimbabwe"
+  }
+]


### PR DESCRIPTION
Add a mapping between countries' full names and their coordinates.
Needed for GCP integration: countries are exported with their full names, not their initials.

As suggested by @amotl, this is the porting of https://github.com/grafana/worldmap-panel/pull/322.